### PR TITLE
Add Travis CI support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,15 @@
 
 language: python
 python:
-    - 2.6
+#    - 2.6
     - 2.7
-    - pypy
-    - 3.2
-    - 3.3
-    - 3.4
-    - 3.5
-    - nightly
-    - pypy3
+#    - pypy
+#    - 3.2
+#    - 3.3
+#    - 3.4
+#    - 3.5
+#    - nightly
+#    - pypy3
 
 install:
     pip install --user django-bootstrap3 django-filer

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@
 
 language: python
 python:
-    - 2.6
+#     - 2.6 # Invalid syntax in File "/home/travis/virtualenv/python2.6.9/lib/python2.6/site-packages/django/utils/lru_cache.py", line 28
     - 2.7
     - pypy
-    - 3.2
+#    - 3.2 # Invalid syntax in File "/home/travis/build/d33tah/django-admin-bootstrapped/django_admin_bootstrapped/../test_django_admin_bootstrapped/test_django_admin_bootstrapped/models.py", line 32
     - 3.3
     - 3.4
     - 3.5
-    - nightly
+#    - nightly # https://bugs.python.org/issue24934
     - pypy3
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,8 @@ python:
     - nightly
     - pypy3
 
+install:
+    pip install --user django-bootstrap3 django-filer
+
 script:
     python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ python:
 #    - pypy3
 
 install:
-    pip install --user django-bootstrap3 django-filer
+    pip install django-bootstrap3 django-filer
 
 script:
     python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,21 @@
 
 language: python
 python:
-#    - 2.6
+    - 2.6
     - 2.7
-#    - pypy
-#    - 3.2
-#    - 3.3
-#    - 3.4
-#    - 3.5
-#    - nightly
-#    - pypy3
+    - pypy
+    - 3.2
+    - 3.3
+    - 3.4
+    - 3.5
+    - nightly
+    - pypy3
+
+env:
+    - DJANGO_VERSION=1.8
 
 install:
-    pip install django-bootstrap3 django-filer
+    pip install django-bootstrap3 django-filer Django==$DJANGO_VERSION
 
 script:
     python setup.py test

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 django-admin-bootstrapped
 =========================
 
+.. image:: https://travis-ci.org/d33tah/django-admin-bootstrapped.svg?branch=travis-ci
+    :target: https://travis-ci.org/d33tah/django-admin-bootstrapped
+
 |PyPI version|
 
 A Django admin theme using Bootstrap. It doesn't need any kind


### PR DESCRIPTION
I noticed that you have a test directory and tests are mentioned are mentioned
in setup.db. Perhaps you could benefit from automated integration tests?
Once you set up a free Travis CI account linked to your GitHub, those would
happen automatically once you push anything not labeled with [ci skip] and
if any tests fail, you'll get an e-mail. Also, you'll be getting your pull
requests tested the same way and you can test for multiple Django/Python
versions easily.
