### PR TITLE
Add Travis CI support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+# http://docs.travis-ci.com/user/languages/python/
+
+language: python
+python:
+#     - 2.6 # Invalid syntax in File "/home/travis/virtualenv/python2.6.9/lib/python2.6/site-packages/django/utils/lru_cache.py", line 28
+    - 2.7
+    - pypy
+#    - 3.2 # Invalid syntax in File "/home/travis/build/d33tah/django-admin-bootstrapped/django_admin_bootstrapped/../test_django_admin_bootstrapped/test_django_admin_bootstrapped/models.py", line 32
+    - 3.3
+    - 3.4
+    - 3.5
+#    - nightly # https://bugs.python.org/issue24934
+    - pypy3
+
+env:
+    - DJANGO_VERSION=1.8
+
+install:
+    pip install django-bootstrap3 django-filer Django==$DJANGO_VERSION
+
+script:
+    python setup.py test
+
+sudo: false

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 django-admin-bootstrapped
 =========================
 
+.. image:: https://travis-ci.org/d33tah/django-admin-bootstrapped.svg?branch=travis-ci
+    :target: https://travis-ci.org/d33tah/django-admin-bootstrapped
+
 |PyPI version|
 
 A Django admin theme using Bootstrap. It doesn't need any kind


### PR DESCRIPTION
I noticed that you have a test directory and tests are mentioned are mentioned
in setup.db. Perhaps you could benefit from automated integration tests?
Once you set up a free Travis CI account linked to your GitHub, those would
happen automatically once you push anything not labeled with [ci skip] and
if any tests fail, you'll get an e-mail. Also, you'll be getting your pull
requests tested the same way and you can test for multiple Django/Python
versions easily.
